### PR TITLE
ci: add nix flake check job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,18 @@
+name: ❄️ Nix
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: ❄️ Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: 🔎 nix flake check
+        run: nix flake check -L


### PR DESCRIPTION
Adds a `❄️ Nix` workflow running `nix flake check` on push + PR to master.

Closes the CI gap flagged after the tailscale bump: `cargo build` never
exercised `nix/package.nix` or the nixosModule. This job builds the flake
checks (package build + cargo tests, module-eval).

Verified locally: `nix flake check` green — 20 tests pass, package + module-eval build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)