### PR TITLE
ci: bump actions off deprecated node 20 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 🛠️ Build
         run: cargo build --verbose

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,7 +8,7 @@ jobs:
   flake-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: ❄️ Install Nix
         uses: cachix/install-nix-action@v30
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🛠️ Setup Rust
@@ -17,7 +17,7 @@ jobs:
         run: cargo install cargo-edit
       - name: 🎨 Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           git-user-name: "chess-seventh"
           git-user-email: "chess7th@pm.me"


### PR DESCRIPTION
Clears the GitHub runner **Node.js 20 deprecation** warning across all jobs.

- `actions/checkout` v4 → v5 (build, nix, release) — node20 → node24
- `TriPSs/conventional-changelog-action` v5 → v6 (release) — node20 → node24

Verified: all inputs/outputs release.yml uses exist unchanged in v6; the only
v6 breaking change is in the `prerelease` option, which release.yml does not set.
Other actions (`ncipollo/release-action@v1` node24, `dtolnay/rust-toolchain`
and `cachix/install-nix-action` composite) were not flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)