### PR TITLE
chore(devenv): bump rusty-commit-saver to 4.17.1

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1763966396,
-        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1764211126,
-        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
+        "lastModified": 1782098508,
+        "narHash": "sha256-YeBVH+avasLg/ZTOyshNI4qfU8p5RbMs9O8944A1QDg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
+        "rev": "67eed429b53d462923d9be580cfc9ed372f7564f",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1777045433,
-        "narHash": "sha256-unyy0WFlyC85TuWPwlY1SX6e39X3zTXzyMQJiaK5hZk=",
+        "lastModified": 1785061245,
+        "narHash": "sha256-oihg7f5013W+uHMYBYswYYwPCvMKK6yQj01X1h2IEs8=",
         "owner": "chess-seventh",
         "repo": "rusty-commit-saver",
-        "rev": "9346c64ed617acd66c3c405d164b339e89c06b35",
+        "rev": "cfcc662cb16ab80ddd4370e72c06b038a2b6566b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The pinned saver predates the [exclude] ini section and panicked on every commit, so nothing was journalled to the diary. Support landed in 4.17.0.

Refs: L66